### PR TITLE
Adjusting hash maximum size

### DIFF
--- a/lib/simple_data_structures/src/hash/hash.h
+++ b/lib/simple_data_structures/src/hash/hash.h
@@ -1,7 +1,7 @@
 #ifndef ARIA_DATA_STRUCTURES_HASH_H
 #define ARIA_DATA_STRUCTURES_HASH_H
 
-#define ARIA_DATA_STRUCTURES_HASH_MAX_SIZE 1000
+#define ARIA_DATA_STRUCTURES_HASH_MAX_SIZE 100
 #include "../linkedlist/list.h"
 
 typedef struct HashTable {


### PR DESCRIPTION
- Since this is an argument parser it isn't reasonable to expect 1000 aruments. So the HashTable max size was adjusted to 100 to save up memory.